### PR TITLE
Use border-box box-sizing

### DIFF
--- a/src/quick-switcher.css
+++ b/src/quick-switcher.css
@@ -31,6 +31,11 @@ body.lstr-qswitcher-noscroll .lstr-qswitcher-container {
   left: 50%;
 }
 
+.lstr-qswitcher-container *
+{
+  box-sizing: border-box;
+}
+
 .lstr-qswitcher-popup
 {
   position: relative;
@@ -41,7 +46,7 @@ body.lstr-qswitcher-noscroll .lstr-qswitcher-container {
 
 input.lstr-qswitcher-search
 {
-  width: 466px;
+  width: 480px;
   border-color: #666666;
   padding: 7px;
   margin: 5px 10px 10px 10px;
@@ -137,7 +142,7 @@ input.lstr-qswitcher-search
 .lstr-qswitcher-results ul
 {
   list-style-type: none;
-  margin: 0 25px 0 0;
+  margin: 0;
   padding: 0;
 }
 


### PR DESCRIPTION
By using border-box box-sizing, padding and borders do
not need to be deducted from widths.

Bootstrap 3 sets box-sizing globally to border-box, so
quick-switcher either needs to set the box-sizing explicitly
so things look decent with Bootstrap 2 or 3 (or none at all).