### PR TITLE
Rename `subtext` to `description` and allow object

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,8 @@
+# Change Log
+
+## v0.1.0
+
+ - Renamed `subtext` to `description`
+   - `description` is now treated as text by default
+   - Use an object with an `html` property as the `description` value to treat
+     the description as HTML

--- a/docs/index.js
+++ b/docs/index.js
@@ -5,6 +5,7 @@
         {
           'breadcrumbText': 'Peoplez',
           'text': 'people',
+          'description': {'html': '&#128269;'},
           'searchCallback': function searchCallback(searchText, peopleResultHandler) {
             setTimeout(function () {
               peopleResultHandler.setResults([

--- a/src/quick-switcher.css
+++ b/src/quick-switcher.css
@@ -172,7 +172,7 @@ li.lstr-qswitcher-result-selected
   border-radius: 3px;
 }
 
-.lstr-qswitcher-results li .lstr-qswitcher-results-subtext {
+.lstr-qswitcher-results li .lstr-qswitcher-results-description {
   font-size: .9em;
   margin-left: 10px;
   float: right;

--- a/src/quick-switcher.js
+++ b/src/quick-switcher.js
@@ -206,8 +206,10 @@
         $li.append($container);
         qSwitcher.setListText($container, value);
 
-        if (value.subtext) {
-          $li.prepend('<span class="lstr-qswitcher-results-subtext">' + value.subtext + '</span>');
+        if (value.description) {
+          var $description = $('<span class="lstr-qswitcher-results-description"></span>');
+          qSwitcher.setListText($description, value.description);
+          $li.prepend($description);
         }
 
         $li.data('lstr-qswitcher', {'index': index});


### PR DESCRIPTION
 - The name `subtext` was not completely clear, so I am
   renaming it to `description`
 - I want `description` to be able to set as text or HTML
   just like the title text