### PR TITLE
Load quick-switcher via requirejs on docs page

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -1,5 +1,11 @@
-(function (root) {
-  root.lstrQuickSwitcher(
+require.config({
+  paths: {
+    'quick-switcher': '../src/quick-switcher'
+  }
+});
+
+define(['quick-switcher'], function(lstrQuickSwitcher) {
+  lstrQuickSwitcher(
     function searchCallback(searchText, basicResultHandler) {
       basicResultHandler.setResults([
         {
@@ -55,4 +61,4 @@
       'searchDelay': 0
     }
   );
-})(window);
+});

--- a/index.html
+++ b/index.html
@@ -39,7 +39,6 @@
 
     <script src="https://code.jquery.com/jquery-3.1.1.js" integrity="sha256-16cdPddA6VdVInumRGo6IbivbERE8p7CQR3HzTBuELA=" crossorigin="anonymous"></script>
     <!--<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>-->
-    <script type="text/javascript" src="dist/quick-switcher.min.js"></script>
-    <script type="text/javascript" src="docs/index.js"></script>
+    <script data-main="docs/index" src="node_modules/requirejs/require.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This will not work on GitHub since `npm install` will not
be ran and requirejs will be missing, but I will fix this
problem in the next few days.