### PR TITLE
Fix flash of "No results found" message

### DIFF
--- a/src/quick-switcher.js
+++ b/src/quick-switcher.js
@@ -280,6 +280,7 @@ define('quick-switcher', ['filters', 'selectors', 'sorters'], function (filters,
     toggleSwitcher: function () {
       this.useRootCallback();
       this.$search.val('');
+      this.searchText = '';
       this.renderList();
 
       this.$parentDom.toggleClass('lstr-qswitcher-noscroll');
@@ -323,6 +324,7 @@ define('quick-switcher', ['filters', 'selectors', 'sorters'], function (filters,
         this.valueObjects = [];
         this.selectIndex(null);
         this.$search.val('');
+        this.searchText = '';
         this.renderList();
 
         return;


### PR DESCRIPTION
If the user enters search text for a sub-search
and then escapes out of the quick-switcher, when
re-opening the quick-switcher the previously entered
search text was briefly being used to search for
results in the main menu.  Clearing out the search text
before hiding/showing the quick-switcher will prevent
the main search from being queried with the previous
value.