### PR TITLE
The eslint was not happy with the syntax

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,10 +1,10 @@
-{
-  baseUrl: "src",
+({
+  baseUrl: 'src',
   name: '../node_modules/almond/almond',
   include: ['quick-switcher'],
-  out: "dist/quick-switcher.min.js",
+  out: 'dist/quick-switcher.min.js',
   wrap: {
     startFile: '.almond/start.frag',
-    endFile: '.almond/end.frag'
-  }
-}
+    endFile: '.almond/end.frag',
+  },
+});


### PR DESCRIPTION
The r.js docs show the config wrapped in parenthesis,
so using that format seems consistent with documentation
and makes eslint happy.