### PR TITLE
Make tracking as easy as setting a config value

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -15,9 +15,10 @@ define(function(require) {
   }
 
   var qs = lstrQuickSwitcher({
+    trackChildrenAs: 'main',
     searchCallback: function(searchText, basicResultHandler) {
       basicResultHandler.setResults(
-        basicResultHandler.sorters.tracker('main').sort([
+        [
           require('docs/search/people'),
           require('docs/search/colors'),
           require('docs/search/error'),
@@ -27,15 +28,11 @@ define(function(require) {
           },
         ].concat(numbers).filter(function(item) {
           return basicResultHandler.filters.isMatch(searchText, item.text);
-        }), searchText)
+        })
       );
     },
     selectCallback: function(selected) {
-      selected.trackAs('main');
       console.log(selected.selectedValue);
-    },
-    selectChildSearchCallback: function(selected) {
-      selected.trackAs('main');
     },
     searchDelay: 0,
   });

--- a/docs/search/people.js
+++ b/docs/search/people.js
@@ -2,11 +2,12 @@ define(function() {
   return {
     breadcrumbText: 'Peoplez',
     text: 'people',
+    trackChildrenAs: 'people',
     trackerId: 'People',
     description: {html: '&#128269;'},
     searchCallback: function searchCallback(searchText, resultHandler) {
       setTimeout(function() {
-        resultHandler.setResults(resultHandler.sorters.tracker('person').sort([
+        resultHandler.setResults([
           'lightster',
           'zulu',
           'ollie',
@@ -35,13 +36,12 @@ define(function() {
             text: item,
             trackerId: item,
           };
-        }), searchText));
+        }));
       }, 1);
     },
     searchDelay: 500,
     selectCallback: function selectCallback(selected) {
       console.log(selected.selectedValue);
-      selected.trackAs('person');
     },
   };
 });

--- a/src/quick-switcher.js
+++ b/src/quick-switcher.js
@@ -46,6 +46,7 @@ var quickSwitcher = function(filters, SelectedResult, sorters, html) {
         selectCallback: options.selectCallback,
         selectChildSearchCallback: options.selectChildSearchCallback,
         searchDelay: options.searchDelay,
+        trackChildrenAs: options.trackChildrenAs,
       });
 
       this.initDomElement($parentDom);
@@ -180,6 +181,10 @@ var quickSwitcher = function(filters, SelectedResult, sorters, html) {
       }
 
       var $ul = $('<ul>');
+
+      if (this.options.trackChildrenAs) {
+        items = sorters.tracker(this.options.trackChildrenAs).sort(items, this.searchText);
+      }
 
       items.forEach(function(value, index) {
         var $li = $('<li>');
@@ -336,10 +341,12 @@ var quickSwitcher = function(filters, SelectedResult, sorters, html) {
 
       var selectedValue = this.valueObjects[index].value;
       var selectedResult = Object.create(SelectedResult);
-      selectedResult.init(selectedValue, this.searchText, event);
+      selectedResult.init(selectedValue, this.searchText, this.options, event);
 
       if (selectedValue.searchCallback) {
-        if (false === this.selectChildSearchCallback(selectedResult)) {
+        var isSelectionAllowed = this.selectChildSearchCallback(selectedResult);
+        selectedResult.track();
+        if (false === isSelectionAllowed) {
           return;
         }
 
@@ -371,7 +378,9 @@ var quickSwitcher = function(filters, SelectedResult, sorters, html) {
         return;
       }
 
-      if (false !== this.selectCallback(selectedResult)) {
+      var isCloseAllowed = this.selectCallback(selectedResult);
+      selectedResult.track();
+      if (false !== isCloseAllowed) {
         this.closeSwitcher();
       }
     },

--- a/src/selected-result.js
+++ b/src/selected-result.js
@@ -1,12 +1,23 @@
 define('selected-result', ['factories'], function(factories) {
   return {
-    init: function init(selectedValue, searchText, domEvent) {
+    init: function init(selectedValue, searchText, parent, domEvent) {
       this.selectedValue = selectedValue;
       this.searchText = searchText;
+      this.parent = parent;
       this.domEvent = domEvent;
+      this.trackingPrevented = false;
     },
-    trackAs: function trackAs(trackerName) {
-      factories.tracker(trackerName).trackSelection(
+
+    preventTracking: function() {
+      this.trackingPrevented = true;
+    },
+
+    track: function track() {
+      if (!this.parent.trackChildrenAs && !this.trackingPrevented) {
+        return;
+      }
+
+      factories.tracker(this.parent.trackChildrenAs).trackSelection(
         this.selectedValue,
         this.searchText
       );

--- a/src/tracker/selection.js
+++ b/src/tracker/selection.js
@@ -27,7 +27,7 @@ define('tracker/selection', ['tracker/statistic'], function(Statistic) {
     increment: function(searchText) {
       this.overall.increment();
 
-      if(!searchText) {
+      if (!searchText) {
         return;
       }
 


### PR DESCRIPTION
Having to manually sort results and to manually track when
a value is selected is cumbersome.  We can make it automatic
by automatically performing those actions if `trackChildrenAs` is
set as a config option.

Issue #54