### PR TITLE
Include all `dist` files when creating release tar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_deploy:
   - yarn build
   - cp README.md LICENSE dist/
   - cd dist
-  - tar czf quick-switcher.tar.gz quick-switcher.min.*
+  - tar czf quick-switcher.tar.gz quick-switcher.min.* README.md LICENSE
   - cd -
 deploy:
   provider: releases


### PR DESCRIPTION
The readme and license were not included in the v0.3.0 release tar even though they are copied to the `dist` directory at build-time. Using a wildcard for the tar source files will make sure anything in the `dist` directory is included.