### PR TITLE
Allow hot key to be disabled

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
  - Update docs to use Jekyll for SCSS compiling
  - Remove `dist` directory
+ - Allow hot key to be disabled by allowing the hot key to be set to null
 
 ## v0.3.0
 

--- a/src/quick-switcher.js
+++ b/src/quick-switcher.js
@@ -39,7 +39,9 @@ var quickSwitcher = function(filters, SelectedResult, sorters, html) {
         hotKey: 'K',
       }, options);
 
-      this.hotKey = options.hotKey.toUpperCase();
+      if (options.hotKey) {
+        this.hotKey = options.hotKey.toUpperCase();
+      }
 
       this.setOptions({
         searchCallback: options.searchCallback,


### PR DESCRIPTION
Setting the hot key to null to disable the hot key makes sense, but in
order for that to be possible we need to uppercase the hot key only when
it is actually set