### PR TITLE
Add button back to docs for demoing on mobile devices

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,7 +6,7 @@ layout: default
 <div class="jumbotron bg-inverse text-white">
   <div class="container">
     <h1 class="display-3">Quick Switcher</h1>
-    <p>A front-end web component to make navigating quick and mouseless.</p>
+    <p class="lead">A front-end web component to make navigating quick and mouseless</p>
   </div>
 </div>
 

--- a/docs/index.js
+++ b/docs/index.js
@@ -37,10 +37,12 @@ define(function(require) {
     searchDelay: 0,
   });
 
-  $('#open-qswitcher').on('click', qs.open.bind(qs));
+  $('.open-qswitcher').on('click', qs.open.bind(qs));
 
   var modifierKey = 'Ctrl';
-  if (navigator.platform.toLowerCase().indexOf('mac') != -1) {
+  if (navigator.platform.toLowerCase().indexOf('mac') != -1
+    || navigator.platform.indexOf('iP') != -1
+  ) {
     modifierKey = 'Cmd';
   }
   $('.qs-hotkey').text(modifierKey + '+K');

--- a/index.md
+++ b/index.md
@@ -2,6 +2,16 @@
 layout: home
 ---
 
-## Try it out
+<div class="jumbotron">
+  <h2>Try it out</h2>
+  <div class="row">
+    <div class="col-md-4">
+      <!-- <h3>Modal</h3> -->
+      <p class="">
+        Type <kbd class="qs-hotkey">Cmd+K / Ctrl+K</kbd> to bring up a demo of the quick switcher.
+      </p>
 
-Type `Cmd+K / Ctrl+K`{: .qs-hotkey } to bring up a demo of the quick switcher.
+      <button class="open-qswitcher btn btn-primary">Open Quick Switcher</button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
When I started revamping the docs, I temporarily removed the button without thinking about it preventing the quick switcher demo being usable on mobile.