### PR TITLE
Remove rounded corners from header

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 
-<div class="jumbotron bg-inverse text-white">
+<div class="jumbotron jumbotron-fluid bg-inverse text-white">
   <div class="container">
     <h1 class="display-3">Quick Switcher</h1>
     <p class="lead">A front-end web component to make navigating quick and mouseless</p>


### PR DESCRIPTION
The header width is set to 100%, so the rounded corners do not look
right