### PR TITLE
Support initializing multiple quick switchers

### DIFF
--- a/src/quick-switcher.js
+++ b/src/quick-switcher.js
@@ -12,6 +12,7 @@ var quickSwitcher = function(filters, SelectedResult, sorters, html) {
 
   var QuickSwitcher = {
     init: function($parentDom, options) {
+      this.isOpen = false;
       this.$parentDom = null;
       this.$liCollection = null;
       this.valueObjects = null;
@@ -91,6 +92,10 @@ var quickSwitcher = function(filters, SelectedResult, sorters, html) {
         }
       });
       $('html').on('keydown', '.lstr-qswitcher-noscroll', function(event) {
+        if (!qSwitcher.isOpen) {
+          return;
+        }
+
         if (event.which === 38) { // up arrow key
           qSwitcher.adjustSelectedIndex(-1);
           event.preventDefault();
@@ -98,7 +103,7 @@ var quickSwitcher = function(filters, SelectedResult, sorters, html) {
           qSwitcher.adjustSelectedIndex(1);
           event.preventDefault();
         } else if (event.which === 27) { // escape key
-          qSwitcher.toggleSwitcher();
+          qSwitcher.closeSwitcher();
           event.preventDefault();
         } else if (13 === event.keyCode) {
           qSwitcher.triggerSelect(qSwitcher.selectedIndex, event);
@@ -318,7 +323,7 @@ var quickSwitcher = function(filters, SelectedResult, sorters, html) {
     },
 
     toggleSwitcher: function() {
-      if (this.$parentDom.hasClass('lstr-qswitcher-noscroll')) {
+      if (this.isOpen) {
         this.closeSwitcher();
         return;
       }
@@ -333,11 +338,15 @@ var quickSwitcher = function(filters, SelectedResult, sorters, html) {
       this.renderList();
 
       this.$parentDom.toggleClass('lstr-qswitcher-noscroll');
+      this.$domElement.show();
+      this.isOpen = true;
       this.$search.focus();
     },
 
     closeSwitcher: function() {
       this.$parentDom.removeClass('lstr-qswitcher-noscroll');
+      this.$domElement.hide();
+      this.isOpen = false;
     },
 
     triggerSelect: function(index, event) {

--- a/src/quick-switcher.scss
+++ b/src/quick-switcher.scss
@@ -7,7 +7,6 @@ body.lstr-qswitcher-noscroll
 body.lstr-qswitcher-noscroll .lstr-qswitcher-overlay,
 body.lstr-qswitcher-noscroll .lstr-qswitcher-container {
   z-index: 9999;
-  display: block;
 }
 
 .lstr-qswitcher-overlay


### PR DESCRIPTION
In order to allow multiple quick switchers to be initialized, I need
to make the quick switcher's visibility decoupled from global state.
As such, using the noscroll class on the body element to decide if the
quick switcher should be visible no longer works. The quick switcher's
visibility needs to be manipulated directly.

The quick switcher now uses .show() and .hide() to control the quick
switcher's visibility

Issue #73