### PR TITLE
Allow snippets to scroll independently of page

### DIFF
--- a/docs/syntax.css
+++ b/docs/syntax.css
@@ -207,6 +207,7 @@
 .highlight {
   background-color: #f8f8f8;
   padding: 10px;
+  overflow-x: auto;
 }
 .highlight .code pre {
   padding-left: 10px;


### PR DESCRIPTION
Code snippets cause the page to scroll horizontally on smaller devices,
such as my phone