### PR TITLE
Add the ability to prevent search text clearing

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -19,22 +19,36 @@ define(function(require) {
   var qs = lstrQuickSwitcher({
     trackChildrenAs: 'main',
     searchCallback: function(searchText, basicResultHandler) {
-      basicResultHandler.setResults(
-        [
-          require('docs/search/people'),
-          require('docs/search/colors'),
-          require('docs/search/error'),
-          {
-            text: 'Quickest Item',
-            trackerId: 'Quickest Item',
-          },
-        ].concat(numbers).filter(function(item) {
-          return basicResultHandler.filters.isMatch(searchText, item.text);
-        })
-      );
+      var colors = require('docs/search/colors');
+      var colorShortcut = Object.create(colors);
+      colorShortcut.text = "Search for color '" + searchText + "'";
+      colorShortcut.isShortcut = true;
+
+      var results = [
+        require('docs/search/people'),
+        colors,
+        require('docs/search/error'),
+        {
+          text: 'Quickest Item',
+          trackerId: 'Quickest Item',
+        },
+      ].concat(numbers).filter(function(item) {
+        return basicResultHandler.filters.isMatch(searchText, item.text);
+      });
+
+      if (searchText) {
+        results.push(colorShortcut);
+      }
+
+      basicResultHandler.setResults(results);
     },
     selectCallback: function(selected) {
       console.log(selected.selectedValue);
+    },
+    selectChildSearchCallback: function(selected) {
+      if (selected.selectedValue.isShortcut) {
+        selected.preventSearchTextClearing();
+      }
     },
     searchDelay: 0,
   });

--- a/src/quick-switcher.js
+++ b/src/quick-switcher.js
@@ -383,11 +383,14 @@ var quickSwitcher = function(filters, SelectedResult, sorters, html) {
             = selectedValue.selectChildSearchCallback;
         }
 
+        if (!selectedResult.isSearchTextClearingPrevented()) {
+          this.$search.val('');
+          this.searchText = '';
+        }
+
         this.valueObjects = [];
         this.selectIndex(null);
-        this.$search.val('');
         this.$search.focus();
-        this.searchText = '';
         this.renderList();
 
         return;

--- a/src/selected-result.js
+++ b/src/selected-result.js
@@ -6,6 +6,7 @@ define('selected-result', ['factories'], function(factories) {
       this.parent = parent;
       this.domEvent = domEvent;
       this.trackingPrevented = false;
+      this.searchTextClearingPrevented = false;
     },
 
     preventTracking: function() {
@@ -21,6 +22,14 @@ define('selected-result', ['factories'], function(factories) {
         this.selectedValue,
         this.searchText
       );
+    },
+
+    preventSearchTextClearing: function preventSearchTextClearing() {
+      this.searchTextClearingPrevented = true;
+    },
+
+    isSearchTextClearingPrevented: function shouldClearSearchText() {
+      return this.searchTextClearingPrevented;
     },
   };
 });


### PR DESCRIPTION
Sometimes we want a subsearch to be always-available in the
quick-switcher so that a search term can be typed and the search term
can be transferred to the subsearch's filter. For example, if there is
a subsearch for colors, we may want the user to be able to type 'green'
on the main search and have an item such as "Search for 'green' colors"
appear. On selection of the subsearch, the subsearch would become active
and 'green' would automatically be searched for within the subsearch.